### PR TITLE
Fix split error and remove unused import in utilities.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# For pycharm ide
+.idea/
+
 config.py
 *.pyc
 certs/* 


### PR DESCRIPTION
1 Using libvirt api to get cpu status not virsh cmd

error message

```
-bash-4.1# python utilities.py
用量：0.1%
Traceback (most recent call last):
File "utilities.py", line 101, in <module>
    get_host_stats()
File "utilities.py", line 27, in get_host_stats
   cpu_system = output[0].split("\t")[1]
IndexError: list index out of range
```
